### PR TITLE
Add CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,50 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+All `dotnet` commands must be run from the `./src` directory.
+
+```bash
+dotnet restore
+dotnet build --no-restore -warnaserror
+dotnet format --verify-no-changes             # check code style (CI enforces this)
+dotnet format && csharpier format .           # auto-fix code style
+dotnet test --no-build --verbosity normal     # run xunit tests
+dotnet pack --configuration Release -p:PackageVersion=<version> --output .
+```
+
+## Architecture
+
+This is a **single-class NuGet library** that provides an EF Core `DbContext` for the Pure.Chart RichRelationalModel.
+
+**Public surface:**
+- `ChartDbContext` (sealed) — primary constructor takes `DbContextOptions<ChartDbContext>`. Exposes four `DbSet<T>` properties: `Charts`, `Types`, `Axes`, `Series`. `OnModelCreating` applies all entity configurations from `Pure.Chart.RichRelationalModel.EFCore.Models.Configurations`.
+
+**Dependency chain:**
+- `Pure.Chart.RichRelationalModel.EFCore.Models.Configurations` supplies the `IEntityTypeConfiguration<T>` implementations (`ChartConfiguration`, `AxisConfiguration`, `ChartTypeConfiguration`, `ChartSeriesConfiguration`) and transitively brings in the EFCore model types and Pure primitive converters/comparers.
+
+**Multi-targeting:** net7.0, net8.0, net9.0, net10.0. `IsAotCompatible` is explicitly `false`.
+
+**Package validation:** `EnablePackageValidation = true` with `PackageValidationBaselineVersion = 0.1.0-preview.5.0.0`. Breaking changes fail the build.
+
+**Publishing:** triggered by pushing a semver tag matching `*.*.*`. The tag name becomes the `PackageVersion`.
+
+**Tests:** the test project (`Pure.Chart.RichRelationalModel.EFCore.Tests`) uses xunit. CI also runs mutation testing via `dotnet-stryker` with `--mutation-level Complete`.
+
+## Code Style
+
+Enforced via `.editorconfig`, `dotnet format --verify-no-changes`, and `csharpier check .` in CI:
+
+- No `var` — always use explicit types
+- File-scoped namespaces required (`csharp_style_namespace_declarations = file_scoped`)
+- No expression-bodied methods or constructors; expression-bodied properties and accessors are required
+- Private fields: `_camelCase` prefix
+- Unused expression results must be assigned to `_` (discard variable)
+- Max line length: 90 characters
+- `using` directives outside the namespace
+
+## Commit Messages
+
+Do not mention Claude or AI assistance in commit messages.


### PR DESCRIPTION
## Summary

- Adds `CLAUDE.md` providing Claude Code with complete guidance for this repository
- Documents all development commands (restore, build, format check, format fix, test, pack) with `./src` as working directory
- Describes the architecture: single-class library exposing `ChartDbContext`, its four `DbSet<T>` properties, dependency on `Pure.Chart.RichRelationalModel.EFCore.Models.Configurations`, multi-targeting, package validation baseline, and semver-tag publish trigger
- Captures non-obvious `.editorconfig` rules: no `var`, file-scoped namespaces, expression-bodied properties required but not methods, `_camelCase` private fields, 90-char line limit, discard variable for unused expression results

Closes #46