### PR TITLE
Update package validation baseline to 0.1.0-preview.5.1.0

### DIFF
--- a/src/Pure.Chart.RichRelationalModel.EFCore/Pure.Chart.RichRelationalModel.EFCore.csproj
+++ b/src/Pure.Chart.RichRelationalModel.EFCore/Pure.Chart.RichRelationalModel.EFCore.csproj
@@ -6,7 +6,7 @@
     <LangVersion>latest</LangVersion>
     <IsAotCompatible>false</IsAotCompatible>
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>0.1.0-preview.5.0.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>0.1.0-preview.5.1.0</PackageValidationBaselineVersion>
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>Pure.Chart.RichRelationalModel.EFCore</PackageId>


### PR DESCRIPTION
Bump `PackageValidationBaselineVersion` from `0.1.0-preview.5.0.0` to `0.1.0-preview.5.1.0` following the successful publish.