### PR TITLE
Update docs references to 0.1.0-preview.5.1.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ This is a **single-class NuGet library** that provides an EF Core `DbContext` fo
 
 **Multi-targeting:** net7.0, net8.0, net9.0, net10.0. `IsAotCompatible` is explicitly `false`.
 
-**Package validation:** `EnablePackageValidation = true` with `PackageValidationBaselineVersion = 0.1.0-preview.5.1.0`. Breaking changes fail the build.
+**Package validation:** `EnablePackageValidation = true` with `PackageValidationBaselineVersion = 0.1.0-preview.5.1.1`. Breaking changes fail the build.
 
 **Publishing:** triggered by pushing a semver tag matching `*.*.*`. The tag name becomes the `PackageVersion`.
 


### PR DESCRIPTION
Update hard-coded version references in documentation from `0.1.0-preview.5.1.0` to `0.1.0-preview.5.1.1` following the release.

## Files updated
- CLAUDE.md